### PR TITLE
Regexp in genregroups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "argparse",
  "chrono",
  "env_logger",
+ "globset",
  "kiddo",
  "log",
  "rand 0.8.5",
@@ -424,6 +425,15 @@ checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -775,6 +785,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,5 @@ serde_json = "1.0.59"
 kiddo = "0.2.3"
 chrono = "0.4.19"
 rand = "0.8.4"
+globset = "0.4.9"
 


### PR DESCRIPTION
Hej,

I tried to add regex to the grenregroups.
The main reason for that is, that sometimes I want a playlist of "Rock", but when you have to type "Soft Rock, Hard Rock, Glam Rock, ..." you get crazy typing all that. Now one can put "glob(*Rock)" or "re(.*Rock)" and that's it.

There are two ways of regex:
- glob() does a GLOB in sqlite querying for matching genres in the db.
- re() does a rust regex on all available genres in the db.

I wrote a function that expands these regex in conjunction with a db query. 
Afterwards everything should work as always. 

I hope I found all places where this regex has to be respected, otherwise please tell me.

There is another folder called "test_regex" which contains my dev program and also serves as a regex test. You only have to set the path to 

Just another comment: With some lines I am not happy... Theres is eg. for `genre in &expanded_groups {` which to me seems odd... But well, I am no computer programmer.

So far I have not been able to test it intensively.

Nevertheless, I hope you like my addon an like to merge the pull request. If there are any things to cleanup, repair, etc. please let me know.
