### PR TITLE
Fix build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
-    - name: Build ARMv7
-      run: docker run --rm -v $(pwd):/source dlecan/rust-crosscompiler-arm:stable
-
-    - name: Build other binaries (x86_64, ARMv8)
+    - name: Build x86_64 and ARM
       run: |
-        docker build -t bliss-mixer-cross - < docker/Dockerfile
-        docker run --rm -v $PWD/target:/build -v $PWD:/src bliss-mixer-cross
+        docker build -t bliss-mixer - < docker/Dockerfile
+        docker run --rm -v $PWD/target:/build -v $PWD:/src bliss-mixer
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # Cross compilation environment for bliss-mixer
 
-FROM debian:stretch
+FROM debian:bullseye
 
 RUN dpkg --add-architecture arm64 && \
     dpkg --add-architecture armhf && \


### PR DESCRIPTION
I changed the files needed for the build according to the build of bliss-analyser.

Therefore, I just left out the specific ARMv7 run. bliss-analyser does build all ARM in the same way as bliss-mixer now.
Everything else is as it was.

In another commit I updated the debian image to bullseye as it is set in bliss-analyser.

I hope that helps building things.